### PR TITLE
Enabled dark and light mode with switch for docs using docsify-darklight-theme

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -6,7 +6,12 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
   <meta name="description" content="Ueno starter kit with next.js">
   <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
-  <link rel="stylesheet" href="//unpkg.com/docsify/lib/themes/vue.css">
+  <link 
+    rel="stylesheet"
+    href="//cdn.jsdelivr.net/npm/docsify-darklight-theme@latest/dist/style.min.css"
+    title="docsify-darklight-theme"
+    type="text/css"
+  />
 </head>
 <body>
   <div id="app"></div>
@@ -18,5 +23,9 @@
     }
   </script>
   <script src="//unpkg.com/docsify/lib/docsify.min.js"></script>
+  <script 
+    src="//cdn.jsdelivr.net/npm/docsify-darklight-theme@latest/dist/index.min.js"
+    type="text/javascript">
+  </script>
 </body>
 </html>


### PR DESCRIPTION
### Light Mode

![image](https://user-images.githubusercontent.com/10001746/94726161-75ab8300-037a-11eb-99d9-bb82c0d62708.png)

### Dark mode

![image](https://user-images.githubusercontent.com/10001746/94726099-63314980-037a-11eb-96a5-225aa2b077d6.png)


